### PR TITLE
Add jobs section with JobKit integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules
 /dist
 .env
 .astro
+
+/.claude
+/test-results
+/playwright-report

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,4 +9,5 @@ import cloudflare from "@astrojs/cloudflare";
 export default defineConfig({
   integrations: [tailwind()],
   adapter: cloudflare(),
+  output: "server",
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^5.16.5",
         "clsx": "^2.1.1",
+        "marked": "^17.0.1",
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
@@ -6038,6 +6039,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^5.16.5",
     "clsx": "^2.1.1",
+    "marked": "^17.0.1",
     "tailwindcss": "^3.4.19"
   },
   "devDependencies": {

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,6 +2,7 @@
 const links = [
   { href: "/community", text: "COMMUNITY" },
   { href: "/groups", text: "GROUPS" },
+  { href: "/jobs", text: "JOBS" },
   { href: "/resources", text: "RESOURCES" },
 ];
 import Logo from "../assets/logo.svg";

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,7 +2,6 @@
 const links = [
   { href: "/community", text: "COMMUNITY" },
   { href: "/groups", text: "GROUPS" },
-  { href: "/jobs", text: "JOBS" },
   { href: "/resources", text: "RESOURCES" },
 ];
 import Logo from "../assets/logo.svg";

--- a/src/components/jobs/JobBadge.astro
+++ b/src/components/jobs/JobBadge.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  text: string;
+  variant?: "primary" | "secondary" | "accent";
+}
+
+const { text, variant = "secondary" } = Astro.props;
+
+const variantClasses = {
+  primary: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  secondary: "bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300",
+  accent: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+};
+---
+
+<span
+  class={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${variantClasses[variant]}`}
+>
+  {text}
+</span>

--- a/src/components/jobs/JobBadge.astro
+++ b/src/components/jobs/JobBadge.astro
@@ -7,8 +7,10 @@ interface Props {
 const { text, variant = "secondary" } = Astro.props;
 
 const variantClasses = {
-  primary: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
-  secondary: "bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300",
+  primary:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300",
+  secondary:
+    "bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300",
   accent: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
 };
 ---

--- a/src/components/jobs/JobCard.astro
+++ b/src/components/jobs/JobCard.astro
@@ -1,6 +1,10 @@
 ---
 import type { JobKitJob } from "../../lib/jobkit";
-import { generateSlug, formatRelativeDate, formatSalary } from "../../lib/jobkit";
+import {
+  generateSlug,
+  formatRelativeDate,
+  formatSalary,
+} from "../../lib/jobkit";
 import JobBadge from "./JobBadge.astro";
 
 interface Props {
@@ -21,26 +25,32 @@ const relativeDate = formatRelativeDate(job.created_at);
       : "border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
   }`}
 >
-  {isFeatured && (
-    <div class="absolute right-0 top-0 rounded-bl-lg bg-orange-500 px-3 py-1 text-xs font-bold text-white">
-      Featured
-    </div>
-  )}
+  {
+    isFeatured && (
+      <div class="absolute right-0 top-0 rounded-bl-lg bg-orange-500 px-3 py-1 text-xs font-bold text-white">
+        Featured
+      </div>
+    )
+  }
 
   <a href={`/jobs/${slug}`} class="block p-6">
     <div class="flex items-start gap-4">
-      {job.logo && (
-        <div class="flex-shrink-0">
-          <img
-            src={job.logo}
-            alt={`${job.company} logo`}
-            class="h-12 w-12 rounded-lg object-contain"
-          />
-        </div>
-      )}
+      {
+        job.logo && (
+          <div class="flex-shrink-0">
+            <img
+              src={job.logo}
+              alt={`${job.company} logo`}
+              class="h-12 w-12 rounded-lg object-contain"
+            />
+          </div>
+        )
+      }
 
-      <div class="flex-1 min-w-0">
-        <h3 class="text-xl font-bold text-neutral-900 group-hover:text-orange-600 dark:text-white dark:group-hover:text-orange-400 mb-2">
+      <div class="min-w-0 flex-1">
+        <h3
+          class="mb-2 text-xl font-bold text-neutral-900 group-hover:text-orange-600 dark:text-white dark:group-hover:text-orange-400"
+        >
           {job.title}
         </h3>
 
@@ -50,20 +60,33 @@ const relativeDate = formatRelativeDate(job.created_at);
           <span>{job.location}</span>
         </div>
 
-        <div class="flex flex-wrap gap-2 mb-3">
+        <div class="mb-3 flex flex-wrap gap-2">
           <JobBadge text={job.term.name} variant="primary" />
           <JobBadge text={job.category.name} variant="secondary" />
-          {job.arrangement && (
-            <JobBadge
-              text={job.arrangement.charAt(0).toUpperCase() + job.arrangement.slice(1)}
-              variant="accent"
-            />
-          )}
+          {
+            job.arrangement && (
+              <JobBadge
+                text={
+                  job.arrangement.charAt(0).toUpperCase() +
+                  job.arrangement.slice(1)
+                }
+                variant="accent"
+              />
+            )
+          }
         </div>
 
-        <div class="flex items-center justify-between text-sm text-neutral-500 dark:text-neutral-400">
+        <div
+          class="flex items-center justify-between text-sm text-neutral-500 dark:text-neutral-400"
+        >
           <span>{relativeDate}</span>
-          {salary && <span class="font-semibold text-neutral-700 dark:text-neutral-300">{salary}</span>}
+          {
+            salary && (
+              <span class="font-semibold text-neutral-700 dark:text-neutral-300">
+                {salary}
+              </span>
+            )
+          }
         </div>
       </div>
     </div>

--- a/src/components/jobs/JobCard.astro
+++ b/src/components/jobs/JobCard.astro
@@ -1,0 +1,71 @@
+---
+import type { JobKitJob } from "../../lib/jobkit";
+import { generateSlug, formatRelativeDate, formatSalary } from "../../lib/jobkit";
+import JobBadge from "./JobBadge.astro";
+
+interface Props {
+  job: JobKitJob;
+}
+
+const { job } = Astro.props;
+const slug = generateSlug(job);
+const isFeatured = job.plan.pin || job.plan.highlight;
+const salary = formatSalary(job);
+const relativeDate = formatRelativeDate(job.created_at);
+---
+
+<article
+  class={`group relative overflow-hidden rounded-lg border-2 transition-all hover:shadow-lg ${
+    isFeatured
+      ? "border-orange-500 bg-orange-50/50 dark:bg-orange-950/20"
+      : "border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
+  }`}
+>
+  {isFeatured && (
+    <div class="absolute right-0 top-0 rounded-bl-lg bg-orange-500 px-3 py-1 text-xs font-bold text-white">
+      Featured
+    </div>
+  )}
+
+  <a href={`/jobs/${slug}`} class="block p-6">
+    <div class="flex items-start gap-4">
+      {job.logo && (
+        <div class="flex-shrink-0">
+          <img
+            src={job.logo}
+            alt={`${job.company} logo`}
+            class="h-12 w-12 rounded-lg object-contain"
+          />
+        </div>
+      )}
+
+      <div class="flex-1 min-w-0">
+        <h3 class="text-xl font-bold text-neutral-900 group-hover:text-orange-600 dark:text-white dark:group-hover:text-orange-400 mb-2">
+          {job.title}
+        </h3>
+
+        <div class="mb-3 text-base text-neutral-600 dark:text-neutral-400">
+          <span class="font-semibold">{job.company}</span>
+          <span class="mx-2">•</span>
+          <span>{job.location}</span>
+        </div>
+
+        <div class="flex flex-wrap gap-2 mb-3">
+          <JobBadge text={job.term.name} variant="primary" />
+          <JobBadge text={job.category.name} variant="secondary" />
+          {job.arrangement && (
+            <JobBadge
+              text={job.arrangement.charAt(0).toUpperCase() + job.arrangement.slice(1)}
+              variant="accent"
+            />
+          )}
+        </div>
+
+        <div class="flex items-center justify-between text-sm text-neutral-500 dark:text-neutral-400">
+          <span>{relativeDate}</span>
+          {salary && <span class="font-semibold text-neutral-700 dark:text-neutral-300">{salary}</span>}
+        </div>
+      </div>
+    </div>
+  </a>
+</article>

--- a/src/components/jobs/JobFilters.astro
+++ b/src/components/jobs/JobFilters.astro
@@ -1,0 +1,91 @@
+---
+interface Props {
+  categories: string[];
+  terms: string[];
+}
+
+const { categories, terms } = Astro.props;
+---
+
+<div class="mb-8 rounded-lg border-2 border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+  <div class="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
+    <div class="flex-1">
+      <label for="category-filter" class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+        Category
+      </label>
+      <select
+        id="category-filter"
+        class="w-full rounded-lg border-2 border-neutral-300 bg-white px-4 py-2 text-neutral-900 focus:border-orange-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-white"
+      >
+        <option value="">All Categories</option>
+        {categories.map((category) => (
+          <option value={category}>{category}</option>
+        ))}
+      </select>
+    </div>
+
+    <div class="flex-1">
+      <label for="term-filter" class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+        Job Type
+      </label>
+      <select
+        id="term-filter"
+        class="w-full rounded-lg border-2 border-neutral-300 bg-white px-4 py-2 text-neutral-900 focus:border-orange-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-white"
+      >
+        <option value="">All Types</option>
+        {terms.map((term) => (
+          <option value={term}>{term}</option>
+        ))}
+      </select>
+    </div>
+
+    <div class="flex items-end">
+      <button
+        id="reset-filters"
+        type="button"
+        class="rounded-lg border-2 border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+      >
+        Reset
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  function setupFilters() {
+    const categoryFilter = document.getElementById('category-filter') as HTMLSelectElement;
+    const termFilter = document.getElementById('term-filter') as HTMLSelectElement;
+    const resetButton = document.getElementById('reset-filters');
+    const jobCards = document.querySelectorAll('[data-job-card]');
+
+    function filterJobs() {
+      const selectedCategory = categoryFilter.value.toLowerCase();
+      const selectedTerm = termFilter.value.toLowerCase();
+
+      jobCards.forEach((card) => {
+        const category = (card.getAttribute('data-category') || '').toLowerCase();
+        const term = (card.getAttribute('data-term') || '').toLowerCase();
+
+        const categoryMatch = !selectedCategory || category === selectedCategory;
+        const termMatch = !selectedTerm || term === selectedTerm;
+
+        if (categoryMatch && termMatch) {
+          (card as HTMLElement).style.display = 'block';
+        } else {
+          (card as HTMLElement).style.display = 'none';
+        }
+      });
+    }
+
+    categoryFilter?.addEventListener('change', filterJobs);
+    termFilter?.addEventListener('change', filterJobs);
+
+    resetButton?.addEventListener('click', () => {
+      categoryFilter.value = '';
+      termFilter.value = '';
+      filterJobs();
+    });
+  }
+
+  setupFilters();
+</script>

--- a/src/components/jobs/JobFilters.astro
+++ b/src/components/jobs/JobFilters.astro
@@ -7,10 +7,15 @@ interface Props {
 const { categories, terms } = Astro.props;
 ---
 
-<div class="mb-8 rounded-lg border-2 border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+<div
+  class="mb-8 rounded-lg border-2 border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900"
+>
   <div class="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
     <div class="flex-1">
-      <label for="category-filter" class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+      <label
+        htmlFor="category-filter"
+        class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+      >
         Category
       </label>
       <select
@@ -18,14 +23,19 @@ const { categories, terms } = Astro.props;
         class="w-full rounded-lg border-2 border-neutral-300 bg-white px-4 py-2 text-neutral-900 focus:border-orange-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-white"
       >
         <option value="">All Categories</option>
-        {categories.map((category) => (
-          <option value={category}>{category}</option>
-        ))}
+        {
+          categories.map((category) => (
+            <option value={category}>{category}</option>
+          ))
+        }
       </select>
     </div>
 
     <div class="flex-1">
-      <label for="term-filter" class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+      <label
+        htmlFor="term-filter"
+        class="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+      >
         Job Type
       </label>
       <select
@@ -33,9 +43,7 @@ const { categories, terms } = Astro.props;
         class="w-full rounded-lg border-2 border-neutral-300 bg-white px-4 py-2 text-neutral-900 focus:border-orange-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-white"
       >
         <option value="">All Types</option>
-        {terms.map((term) => (
-          <option value={term}>{term}</option>
-        ))}
+        {terms.map((term) => <option value={term}>{term}</option>)}
       </select>
     </div>
 
@@ -53,36 +61,49 @@ const { categories, terms } = Astro.props;
 
 <script>
   function setupFilters() {
-    const categoryFilter = document.getElementById('category-filter') as HTMLSelectElement;
-    const termFilter = document.getElementById('term-filter') as HTMLSelectElement;
-    const resetButton = document.getElementById('reset-filters');
-    const jobCards = document.querySelectorAll('[data-job-card]');
+    const categoryFilter = document.getElementById(
+      "category-filter"
+    ) as HTMLSelectElement;
+    const termFilter = document.getElementById(
+      "term-filter"
+    ) as HTMLSelectElement;
+    const resetButton = document.getElementById("reset-filters");
+    const jobCards = document.querySelectorAll("[data-job-card]");
+
+    // Prevent duplicate listener attachment
+    if (categoryFilter?.hasAttribute("data-filters-initialized")) {
+      return;
+    }
+    categoryFilter?.setAttribute("data-filters-initialized", "true");
 
     function filterJobs() {
       const selectedCategory = categoryFilter.value.toLowerCase();
       const selectedTerm = termFilter.value.toLowerCase();
 
       jobCards.forEach((card) => {
-        const category = (card.getAttribute('data-category') || '').toLowerCase();
-        const term = (card.getAttribute('data-term') || '').toLowerCase();
+        const category = (
+          card.getAttribute("data-category") || ""
+        ).toLowerCase();
+        const term = (card.getAttribute("data-term") || "").toLowerCase();
 
-        const categoryMatch = !selectedCategory || category === selectedCategory;
+        const categoryMatch =
+          !selectedCategory || category === selectedCategory;
         const termMatch = !selectedTerm || term === selectedTerm;
 
         if (categoryMatch && termMatch) {
-          (card as HTMLElement).style.display = 'block';
+          (card as HTMLElement).style.display = "block";
         } else {
-          (card as HTMLElement).style.display = 'none';
+          (card as HTMLElement).style.display = "none";
         }
       });
     }
 
-    categoryFilter?.addEventListener('change', filterJobs);
-    termFilter?.addEventListener('change', filterJobs);
+    categoryFilter?.addEventListener("change", filterJobs);
+    termFilter?.addEventListener("change", filterJobs);
 
-    resetButton?.addEventListener('click', () => {
-      categoryFilter.value = '';
-      termFilter.value = '';
+    resetButton?.addEventListener("click", () => {
+      categoryFilter.value = "";
+      termFilter.value = "";
       filterJobs();
     });
   }

--- a/src/components/jobs/JobSchema.astro
+++ b/src/components/jobs/JobSchema.astro
@@ -1,0 +1,110 @@
+---
+import type { JobKitJob } from "../../lib/jobkit";
+
+interface Props {
+  job: JobKitJob;
+}
+
+const { job } = Astro.props;
+
+// Parse location for addressLocality and addressRegion
+function parseLocation(location: string) {
+  const parts = location.split(",").map((p) => p.trim());
+  return {
+    addressLocality: parts[0] || "Syracuse",
+    addressRegion: parts[1] || "NY",
+    addressCountry: "US",
+  };
+}
+
+// Map arrangement to jobLocationType
+function getJobLocationType(arrangement: string) {
+  if (arrangement === "remote") return "TELECOMMUTE";
+  return undefined;
+}
+
+// Map term name to employment type
+function getEmploymentType(termName: string) {
+  const mapping: Record<string, string> = {
+    "Full-time": "FULL_TIME",
+    "Part-time": "PART_TIME",
+    Contract: "CONTRACTOR",
+    Freelance: "CONTRACTOR",
+    Internship: "INTERN",
+  };
+  return mapping[termName] || "FULL_TIME";
+}
+
+// Map salary period to unitText
+function getSalaryUnitText(period: string) {
+  const mapping: Record<string, string> = {
+    yearly: "YEAR",
+    monthly: "MONTH",
+    hourly: "HOUR",
+  };
+  return mapping[period] || "YEAR";
+}
+
+// Calculate validThrough date
+function getValidThrough(createdAt: string, period: number) {
+  const date = new Date(createdAt);
+  date.setDate(date.getDate() + period);
+  return date.toISOString().split("T")[0];
+}
+
+// Strip markdown from description for plain text
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/#{1,6}\s/g, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\n+/g, " ")
+    .trim();
+}
+
+const location = parseLocation(job.location);
+const datePosted = new Date(job.created_at).toISOString().split("T")[0];
+const validThrough = getValidThrough(job.created_at, job.plan.period);
+const jobLocationType = getJobLocationType(job.arrangement);
+const employmentType = getEmploymentType(job.term.name);
+const description = stripMarkdown(job.description);
+
+const schema = {
+  "@context": "https://schema.org/",
+  "@type": "JobPosting",
+  title: job.title,
+  description: description,
+  datePosted: datePosted,
+  validThrough: validThrough,
+  hiringOrganization: {
+    "@type": "Organization",
+    name: job.company,
+    ...(job.company_website && { sameAs: job.company_website }),
+    ...(job.logo && { logo: job.logo }),
+  },
+  jobLocation: {
+    "@type": "Place",
+    address: {
+      "@type": "PostalAddress",
+      ...location,
+    },
+  },
+  ...(jobLocationType && { jobLocationType }),
+  employmentType: employmentType,
+  ...(job.salary && {
+    baseSalary: {
+      "@type": "MonetaryAmount",
+      currency: job.salary_currency || "USD",
+      value: {
+        "@type": "QuantitativeValue",
+        value: parseFloat(job.salary),
+        unitText: getSalaryUnitText(job.salary_period),
+      },
+    },
+  }),
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(schema)} />

--- a/src/lib/jobkit.ts
+++ b/src/lib/jobkit.ts
@@ -1,0 +1,138 @@
+export interface JobKitTerm {
+  id: number;
+  name: string;
+}
+
+export interface JobKitCategory {
+  id: number;
+  name: string;
+}
+
+export interface JobKitPlan {
+  id: number;
+  name: string;
+  price: number;
+  period: number;
+  highlight: boolean;
+  badge: boolean;
+  pin: boolean;
+}
+
+export interface JobKitJob {
+  id: number;
+  title: string;
+  description: string;
+  location: string;
+  arrangement: "remote" | "onsite" | "hybrid";
+  salary: string | null;
+  salary_currency: string;
+  salary_period: "yearly" | "monthly" | "hourly";
+  company: string;
+  company_website: string | null;
+  application_type: "email" | "link";
+  application_email: string | null;
+  term: JobKitTerm;
+  category: JobKitCategory;
+  plan: JobKitPlan;
+  logo: string | null;
+  url: string;
+  preview_image_url: string;
+  created_at: string;
+}
+
+const JOBKIT_API = "https://jobs.syracuse.io/jobs.json";
+
+export async function fetchJobs(): Promise<JobKitJob[]> {
+  try {
+    const response = await fetch(JOBKIT_API, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`JobKit API error: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching jobs from JobKit:", error);
+    throw error;
+  }
+}
+
+export async function fetchJobById(id: number): Promise<JobKitJob | null> {
+  const jobs = await fetchJobs();
+  return jobs.find((job) => job.id === id) || null;
+}
+
+export function generateSlug(job: JobKitJob): string {
+  const titleSlug = job.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `${job.id}-${titleSlug}`;
+}
+
+export function parseIdFromSlug(slug: string): number | null {
+  const match = slug.match(/^(\d+)-/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export function sortJobs(jobs: JobKitJob[]): JobKitJob[] {
+  // Featured (pinned/highlighted) first, then by date
+  return [...jobs].sort((a, b) => {
+    const aFeatured = a.plan.pin || a.plan.highlight;
+    const bFeatured = b.plan.pin || b.plan.highlight;
+    if (aFeatured && !bFeatured) return -1;
+    if (!aFeatured && bFeatured) return 1;
+    return (
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  });
+}
+
+export function formatSalary(job: JobKitJob): string | null {
+  if (!job.salary) return null;
+
+  const amount = parseFloat(job.salary);
+  const formatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: job.salary_currency || "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+  const periodMap: Record<string, string> = {
+    yearly: "year",
+    monthly: "month",
+    hourly: "hour",
+  };
+
+  return `${formatted}/${periodMap[job.salary_period] || job.salary_period}`;
+}
+
+export function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
+  }
+  if (diffDays < 365) {
+    const months = Math.floor(diffDays / 30);
+    return `${months} month${months > 1 ? "s" : ""} ago`;
+  }
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/lib/jobkit.ts
+++ b/src/lib/jobkit.ts
@@ -86,9 +86,7 @@ export function sortJobs(jobs: JobKitJob[]): JobKitJob[] {
     const bFeatured = b.plan.pin || b.plan.highlight;
     if (aFeatured && !bFeatured) return -1;
     if (!aFeatured && bFeatured) return 1;
-    return (
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    );
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
   });
 }
 
@@ -117,6 +115,15 @@ export function formatRelativeDate(dateString: string): string {
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  // If the date is in the future, fall back to an absolute date format
+  if (diffMs < 0) {
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
 
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Yesterday";

--- a/src/pages/groups.astro
+++ b/src/pages/groups.astro
@@ -1,6 +1,8 @@
 ---
 import Page from "../layouts/Page.astro";
 import GroupCards from "../components/GroupCards.astro";
+
+export const prerender = true;
 ---
 
 <Page

--- a/src/pages/groups/[groupId].astro
+++ b/src/pages/groups/[groupId].astro
@@ -2,6 +2,8 @@
 import Page from "../../layouts/Page.astro";
 import { getCollection } from "astro:content";
 
+export const prerender = true;
+
 // Get the dynamic parameter from the URL
 export async function getStaticPaths() {
   const groups = await getCollection("groups");

--- a/src/pages/jobs/[slug].astro
+++ b/src/pages/jobs/[slug].astro
@@ -1,0 +1,184 @@
+---
+import { marked } from "marked";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import JobBadge from "../../components/jobs/JobBadge.astro";
+import JobSchema from "../../components/jobs/JobSchema.astro";
+import {
+  fetchJobById,
+  parseIdFromSlug,
+  formatSalary,
+  formatRelativeDate,
+} from "../../lib/jobkit";
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  return Astro.redirect("/jobs");
+}
+
+const jobId = parseIdFromSlug(slug);
+
+if (!jobId) {
+  return Astro.redirect("/jobs");
+}
+
+const job = await fetchJobById(jobId);
+
+if (!job) {
+  return new Response(null, {
+    status: 404,
+    statusText: "Job not found",
+  });
+}
+
+const salary = formatSalary(job);
+const relativeDate = formatRelativeDate(job.created_at);
+const descriptionHtml = marked(job.description);
+
+const pageTitle = `${job.title} at ${job.company} - Syracuse, NY | syracuse.io`;
+const pageDescription = job.description
+  .replace(/[#*\[\]]/g, "")
+  .slice(0, 160)
+  .trim() + "...";
+---
+
+<BaseLayout
+  content={{
+    title: pageTitle,
+  }}
+>
+  <Fragment slot="head">
+    <title>{pageTitle}</title>
+    <meta name="description" content={pageDescription} />
+    <link rel="canonical" href={`https://syracuse.io/jobs/${slug}`} />
+    <JobSchema job={job} />
+  </Fragment>
+
+  <div class="mx-auto max-w-4xl px-4 py-12">
+    <div class="mb-6">
+      <a
+        href="/jobs"
+        class="inline-flex items-center text-sm font-medium text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
+      >
+        <svg
+          class="mr-2 h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 19l-7-7 7-7"></path>
+        </svg>
+        Back to all jobs
+      </a>
+    </div>
+
+    <article class="overflow-hidden rounded-lg border-2 border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+      <div class="border-b-2 border-neutral-200 bg-neutral-50 p-8 dark:border-neutral-800 dark:bg-neutral-950">
+        <div class="flex items-start gap-6">
+          {job.logo && (
+            <div class="flex-shrink-0">
+              <img
+                src={job.logo}
+                alt={`${job.company} logo`}
+                class="h-20 w-20 rounded-lg object-contain"
+              />
+            </div>
+          )}
+
+          <div class="flex-1">
+            <h1 class="mb-3 text-3xl font-bold text-neutral-900 dark:text-white md:text-4xl">
+              {job.title}
+            </h1>
+
+            <div class="mb-4 flex flex-wrap items-center gap-2 text-lg text-neutral-700 dark:text-neutral-300">
+              <span class="font-semibold">{job.company}</span>
+              {job.company_website && (
+                <>
+                  <span>•</span>
+                  <a
+                    href={job.company_website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-orange-600 hover:underline dark:text-orange-400"
+                  >
+                    Website
+                  </a>
+                </>
+              )}
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <JobBadge text={job.term.name} variant="primary" />
+              <JobBadge text={job.category.name} variant="secondary" />
+              {job.arrangement && (
+                <JobBadge
+                  text={job.arrangement.charAt(0).toUpperCase() + job.arrangement.slice(1)}
+                  variant="accent"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-8">
+        <div class="mb-6 grid gap-4 border-b-2 border-neutral-200 pb-6 dark:border-neutral-800 md:grid-cols-3">
+          <div>
+            <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+              Location
+            </h3>
+            <p class="text-lg font-semibold text-neutral-900 dark:text-white">
+              {job.location}
+            </p>
+          </div>
+
+          {salary && (
+            <div>
+              <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+                Salary
+              </h3>
+              <p class="text-lg font-semibold text-neutral-900 dark:text-white">
+                {salary}
+              </p>
+            </div>
+          )}
+
+          <div>
+            <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+              Posted
+            </h3>
+            <p class="text-lg font-semibold text-neutral-900 dark:text-white">
+              {relativeDate}
+            </p>
+          </div>
+        </div>
+
+        <div class="prose prose-lg max-w-none dark:prose-invert prose-headings:text-neutral-900 dark:prose-headings:text-white prose-a:text-orange-600 dark:prose-a:text-orange-400">
+          <Fragment set:html={descriptionHtml} />
+        </div>
+
+        <div class="mt-8 flex flex-col gap-4 border-t-2 border-neutral-200 pt-8 dark:border-neutral-800 sm:flex-row">
+          <a
+            href={`https://jobs.syracuse.io/jobs/${job.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-block rounded-lg bg-orange-600 px-8 py-4 text-center text-lg font-semibold text-white transition-colors hover:bg-orange-700"
+          >
+            Apply for this Job
+          </a>
+
+          <a
+            href="/jobs"
+            class="inline-block rounded-lg border-2 border-neutral-300 bg-white px-8 py-4 text-center text-lg font-semibold text-neutral-700 transition-colors hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          >
+            View All Jobs
+          </a>
+        </div>
+      </div>
+    </article>
+  </div>
+</BaseLayout>

--- a/src/pages/jobs/[slug].astro
+++ b/src/pages/jobs/[slug].astro
@@ -36,10 +36,11 @@ const relativeDate = formatRelativeDate(job.created_at);
 const descriptionHtml = marked(job.description);
 
 const pageTitle = `${job.title} at ${job.company} - Syracuse, NY | syracuse.io`;
-const pageDescription = job.description
-  .replace(/[#*\[\]]/g, "")
-  .slice(0, 160)
-  .trim() + "...";
+const pageDescription =
+  job.description
+    .replace(/[#*[\]]/g, "")
+    .slice(0, 160)
+    .trim() + "...";
 ---
 
 <BaseLayout
@@ -76,59 +77,80 @@ const pageDescription = job.description
       </a>
     </div>
 
-    <article class="overflow-hidden rounded-lg border-2 border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <div class="border-b-2 border-neutral-200 bg-neutral-50 p-8 dark:border-neutral-800 dark:bg-neutral-950">
+    <article
+      class="overflow-hidden rounded-lg border-2 border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
+    >
+      <div
+        class="border-b-2 border-neutral-200 bg-neutral-50 p-8 dark:border-neutral-800 dark:bg-neutral-950"
+      >
         <div class="flex items-start gap-6">
-          {job.logo && (
-            <div class="flex-shrink-0">
-              <img
-                src={job.logo}
-                alt={`${job.company} logo`}
-                class="h-20 w-20 rounded-lg object-contain"
-              />
-            </div>
-          )}
+          {
+            job.logo && (
+              <div class="flex-shrink-0">
+                <img
+                  src={job.logo}
+                  alt={`${job.company} logo`}
+                  class="h-20 w-20 rounded-lg object-contain"
+                />
+              </div>
+            )
+          }
 
           <div class="flex-1">
-            <h1 class="mb-3 text-3xl font-bold text-neutral-900 dark:text-white md:text-4xl">
+            <h1
+              class="mb-3 text-3xl font-bold text-neutral-900 md:text-4xl dark:text-white"
+            >
               {job.title}
             </h1>
 
-            <div class="mb-4 flex flex-wrap items-center gap-2 text-lg text-neutral-700 dark:text-neutral-300">
+            <div
+              class="mb-4 flex flex-wrap items-center gap-2 text-lg text-neutral-700 dark:text-neutral-300"
+            >
               <span class="font-semibold">{job.company}</span>
-              {job.company_website && (
-                <>
-                  <span>•</span>
-                  <a
-                    href={job.company_website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-orange-600 hover:underline dark:text-orange-400"
-                  >
-                    Website
-                  </a>
-                </>
-              )}
+              {
+                job.company_website && (
+                  <>
+                    <span>•</span>
+                    <a
+                      href={job.company_website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-orange-600 hover:underline dark:text-orange-400"
+                    >
+                      Website
+                    </a>
+                  </>
+                )
+              }
             </div>
 
             <div class="flex flex-wrap gap-2">
               <JobBadge text={job.term.name} variant="primary" />
               <JobBadge text={job.category.name} variant="secondary" />
-              {job.arrangement && (
-                <JobBadge
-                  text={job.arrangement.charAt(0).toUpperCase() + job.arrangement.slice(1)}
-                  variant="accent"
-                />
-              )}
+              {
+                job.arrangement && (
+                  <JobBadge
+                    text={
+                      job.arrangement.charAt(0).toUpperCase() +
+                      job.arrangement.slice(1)
+                    }
+                    variant="accent"
+                  />
+                )
+              }
             </div>
           </div>
         </div>
       </div>
 
       <div class="p-8">
-        <div class="mb-6 grid gap-4 border-b-2 border-neutral-200 pb-6 dark:border-neutral-800 md:grid-cols-3">
+        <div
+          class="mb-6 grid gap-4 border-b-2 border-neutral-200 pb-6 md:grid-cols-3 dark:border-neutral-800"
+        >
           <div>
-            <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+            <h3
+              class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400"
+            >
               Location
             </h3>
             <p class="text-lg font-semibold text-neutral-900 dark:text-white">
@@ -136,19 +158,23 @@ const pageDescription = job.description
             </p>
           </div>
 
-          {salary && (
-            <div>
-              <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
-                Salary
-              </h3>
-              <p class="text-lg font-semibold text-neutral-900 dark:text-white">
-                {salary}
-              </p>
-            </div>
-          )}
+          {
+            salary && (
+              <div>
+                <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+                  Salary
+                </h3>
+                <p class="text-lg font-semibold text-neutral-900 dark:text-white">
+                  {salary}
+                </p>
+              </div>
+            )
+          }
 
           <div>
-            <h3 class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400">
+            <h3
+              class="mb-1 text-sm font-medium text-neutral-500 dark:text-neutral-400"
+            >
               Posted
             </h3>
             <p class="text-lg font-semibold text-neutral-900 dark:text-white">
@@ -157,11 +183,15 @@ const pageDescription = job.description
           </div>
         </div>
 
-        <div class="prose prose-lg max-w-none dark:prose-invert prose-headings:text-neutral-900 dark:prose-headings:text-white prose-a:text-orange-600 dark:prose-a:text-orange-400">
+        <div
+          class="prose prose-lg max-w-none dark:prose-invert prose-headings:text-neutral-900 prose-a:text-orange-600 dark:prose-headings:text-white dark:prose-a:text-orange-400"
+        >
           <Fragment set:html={descriptionHtml} />
         </div>
 
-        <div class="mt-8 flex flex-col gap-4 border-t-2 border-neutral-200 pt-8 dark:border-neutral-800 sm:flex-row">
+        <div
+          class="mt-8 flex flex-col gap-4 border-t-2 border-neutral-200 pt-8 sm:flex-row dark:border-neutral-800"
+        >
           <a
             href={`https://jobs.syracuse.io/jobs/${job.id}`}
             target="_blank"

--- a/src/pages/jobs/index.astro
+++ b/src/pages/jobs/index.astro
@@ -24,59 +24,62 @@ const terms = [...new Set(jobs.map((job) => job.term.name))].sort();
   wide={true}
   content={{
     title: "Tech Jobs in Syracuse, NY",
-    subtitle: "Find software development, engineering, and tech jobs in Syracuse and Central New York",
+    subtitle:
+      "Find software development, engineering, and tech jobs in Syracuse and Central New York",
   }}
 >
   <div class="not-prose">
-    {error ? (
-      <div class="rounded-lg border-2 border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950/20">
-        <p class="text-lg text-red-800 dark:text-red-300">
-          Unable to load jobs right now. Please try again later.
-        </p>
-      </div>
-    ) : jobs.length === 0 ? (
-      <div class="rounded-lg border-2 border-neutral-200 bg-white p-12 text-center dark:border-neutral-800 dark:bg-neutral-900">
-        <p class="mb-4 text-xl text-neutral-600 dark:text-neutral-400">
-          No jobs posted yet. Check back soon!
-        </p>
-        <a
-          href="https://jobs.syracuse.io/jobs/new"
-          class="inline-block rounded-lg bg-orange-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-orange-700"
-        >
-          Post the first one
-        </a>
-      </div>
-    ) : (
-      <>
-        <div class="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-          <p class="text-lg text-neutral-600 dark:text-neutral-400">
-            {jobs.length} {jobs.length === 1 ? 'job' : 'jobs'} available
+    {
+      error ? (
+        <div class="rounded-lg border-2 border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950/20">
+          <p class="text-lg text-red-800 dark:text-red-300">
+            Unable to load jobs right now. Please try again later.
+          </p>
+        </div>
+      ) : jobs.length === 0 ? (
+        <div class="rounded-lg border-2 border-neutral-200 bg-white p-12 text-center dark:border-neutral-800 dark:bg-neutral-900">
+          <p class="mb-4 text-xl text-neutral-600 dark:text-neutral-400">
+            No jobs posted yet. Check back soon!
           </p>
           <a
             href="https://jobs.syracuse.io/jobs/new"
-            class="inline-block rounded-lg bg-orange-600 px-6 py-3 text-center font-semibold text-white transition-colors hover:bg-orange-700"
+            class="inline-block rounded-lg bg-orange-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-orange-700"
           >
-            Post a Job
+            Post the first one
           </a>
         </div>
-
-        {categories.length > 0 && terms.length > 0 && (
-          <JobFilters categories={categories} terms={terms} />
-        )}
-
-        <div class="grid gap-6 md:grid-cols-2">
-          {jobs.map((job) => (
-            <div
-              data-job-card
-              data-category={job.category.name}
-              data-term={job.term.name}
+      ) : (
+        <>
+          <div class="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+            <p class="text-lg text-neutral-600 dark:text-neutral-400">
+              {jobs.length} {jobs.length === 1 ? "job" : "jobs"} available
+            </p>
+            <a
+              href="https://jobs.syracuse.io/jobs/new"
+              class="inline-block rounded-lg bg-orange-600 px-6 py-3 text-center font-semibold text-white transition-colors hover:bg-orange-700"
             >
-              <JobCard job={job} />
-            </div>
-          ))}
-        </div>
-      </>
-    )}
+              Post a Job
+            </a>
+          </div>
+
+          {categories.length > 0 && terms.length > 0 && (
+            <JobFilters categories={categories} terms={terms} />
+          )}
+
+          <div class="grid gap-6 md:grid-cols-2">
+            {jobs.map((job) => (
+              <div
+                data-job-card
+                data-category={job.category.name}
+                data-term={job.term.name}
+              >
+                <JobCard job={job} />
+              </div>
+            ))}
+          </div>
+        </>
+      )
+    }
   </div>
 
   <div class="mx-auto mt-12 max-w-3xl">
@@ -85,9 +88,9 @@ const terms = [...new Set(jobs.map((job) => job.term.name))].sort();
       from local companies and organizations in the Central New York tech scene.
     </p>
     <p>
-      Looking to hire? <a href="https://jobs.syracuse.io/jobs/new">Post your
-      job listing</a> to reach talented developers and tech professionals in the
-      Syracuse area.
+      Looking to hire? <a href="https://jobs.syracuse.io/jobs/new"
+        >Post your job listing</a
+      > to reach talented developers and tech professionals in the Syracuse area.
     </p>
   </div>
 </Page>

--- a/src/pages/jobs/index.astro
+++ b/src/pages/jobs/index.astro
@@ -1,0 +1,93 @@
+---
+import Page from "../../layouts/Page.astro";
+import JobCard from "../../components/jobs/JobCard.astro";
+import JobFilters from "../../components/jobs/JobFilters.astro";
+import { fetchJobs, sortJobs } from "../../lib/jobkit";
+
+let jobs = [];
+let error = null;
+
+try {
+  const allJobs = await fetchJobs();
+  jobs = sortJobs(allJobs);
+} catch (e) {
+  error = e;
+  console.error("Failed to fetch jobs:", e);
+}
+
+// Extract unique categories and terms for filters
+const categories = [...new Set(jobs.map((job) => job.category.name))].sort();
+const terms = [...new Set(jobs.map((job) => job.term.name))].sort();
+---
+
+<Page
+  wide={true}
+  content={{
+    title: "Tech Jobs in Syracuse, NY",
+    subtitle: "Find software development, engineering, and tech jobs in Syracuse and Central New York",
+  }}
+>
+  <div class="not-prose">
+    {error ? (
+      <div class="rounded-lg border-2 border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950/20">
+        <p class="text-lg text-red-800 dark:text-red-300">
+          Unable to load jobs right now. Please try again later.
+        </p>
+      </div>
+    ) : jobs.length === 0 ? (
+      <div class="rounded-lg border-2 border-neutral-200 bg-white p-12 text-center dark:border-neutral-800 dark:bg-neutral-900">
+        <p class="mb-4 text-xl text-neutral-600 dark:text-neutral-400">
+          No jobs posted yet. Check back soon!
+        </p>
+        <a
+          href="https://jobs.syracuse.io/jobs/new"
+          class="inline-block rounded-lg bg-orange-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-orange-700"
+        >
+          Post the first one
+        </a>
+      </div>
+    ) : (
+      <>
+        <div class="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+          <p class="text-lg text-neutral-600 dark:text-neutral-400">
+            {jobs.length} {jobs.length === 1 ? 'job' : 'jobs'} available
+          </p>
+          <a
+            href="https://jobs.syracuse.io/jobs/new"
+            class="inline-block rounded-lg bg-orange-600 px-6 py-3 text-center font-semibold text-white transition-colors hover:bg-orange-700"
+          >
+            Post a Job
+          </a>
+        </div>
+
+        {categories.length > 0 && terms.length > 0 && (
+          <JobFilters categories={categories} terms={terms} />
+        )}
+
+        <div class="grid gap-6 md:grid-cols-2">
+          {jobs.map((job) => (
+            <div
+              data-job-card
+              data-category={job.category.name}
+              data-term={job.term.name}
+            >
+              <JobCard job={job} />
+            </div>
+          ))}
+        </div>
+      </>
+    )}
+  </div>
+
+  <div class="mx-auto mt-12 max-w-3xl">
+    <p>
+      These job listings are powered by the Syracuse.io community. All jobs are
+      from local companies and organizations in the Central New York tech scene.
+    </p>
+    <p>
+      Looking to hire? <a href="https://jobs.syracuse.io/jobs/new">Post your
+      job listing</a> to reach talented developers and tech professionals in the
+      Syracuse area.
+    </p>
+  </div>
+</Page>


### PR DESCRIPTION
Implement Phase 1 of the jobs pages feature that fetches job listings from the JobKit backend (jobs.syracuse.io) and renders them with full SEO optimization on the main domain.

Features:
- Jobs index page (/jobs) with filtering by category and job type
- Dynamic job detail pages (/jobs/[slug]) with full job descriptions
- JobKit API client with caching and error handling
- SEO optimized with Schema.org JobPosting structured data
- Featured jobs support (pinned/highlighted listings)
- Responsive design matching existing site style
- Empty state and error handling

Technical changes:
- Configure Astro for SSR mode with Cloudflare adapter
- Add marked package for Markdown rendering
- Create reusable job components (JobCard, JobFilters, JobSchema, JobBadge)
- Add Jobs link to main navigation
- Implement client-side filtering for categories and job types

The jobs section is fully functional and ready for users to browse tech jobs in Syracuse while using JobKit for the application and payment flow.