### PR TITLE
Improve Meetup page load reliability with faster timeout

### DIFF
--- a/scripts/fetch-meetup-events.mjs
+++ b/scripts/fetch-meetup-events.mjs
@@ -32,7 +32,7 @@ async function scrapeMeetupEvents() {
   const page = await browser.newPage();
 
   console.log(`Fetching events from ${MEETUP_GROUP_URL}`);
-  await page.goto(MEETUP_GROUP_URL, { waitUntil: "networkidle" });
+  await page.goto(MEETUP_GROUP_URL, { waitUntil: "domcontentloaded", timeout: 60000 });
 
   // Wait for event cards to render (Meetup is a React SPA)
   // Use a generous timeout — if no events exist the selector simply won't appear

--- a/scripts/fetch-meetup-events.mjs
+++ b/scripts/fetch-meetup-events.mjs
@@ -32,7 +32,10 @@ async function scrapeMeetupEvents() {
   const page = await browser.newPage();
 
   console.log(`Fetching events from ${MEETUP_GROUP_URL}`);
-  await page.goto(MEETUP_GROUP_URL, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.goto(MEETUP_GROUP_URL, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 
   // Wait for event cards to render (Meetup is a React SPA)
   // Use a generous timeout — if no events exist the selector simply won't appear


### PR DESCRIPTION
## Summary
Updated the page navigation strategy in the Meetup events scraper to improve reliability and reduce wait times when fetching event data.

## Key Changes
- Changed `waitUntil` option from `"networkidle"` to `"domcontentloaded"` to proceed as soon as the DOM is ready rather than waiting for all network activity to complete
- Added explicit `timeout: 60000` (60 seconds) to prevent indefinite hangs and provide a clear failure boundary

## Implementation Details
The `"networkidle"` strategy can be overly conservative for single-page applications like Meetup, potentially waiting for background requests that aren't necessary for event card rendering. By switching to `"domcontentloaded"`, the script will proceed faster while still ensuring the page structure is available. The explicit timeout provides a safety net to prevent the script from hanging indefinitely if the page fails to load properly.

https://claude.ai/code/session_01UmeH1dzcAquryJ8pQ8k5Cs